### PR TITLE
Hardcoded fix for incorrect grid lengths

### DIFF
--- a/lightsout/src/components/Grid.js
+++ b/lightsout/src/components/Grid.js
@@ -26,7 +26,7 @@ class Grid extends React.Component {
       i, // Selected tile
       (i + 1) % 5 ? i + 1 : NONE, // Tile on right, account for right edge of grid
       i + 5 // Tile above
-    ].filter(i => 0 <= i <= this.state.tiles.length) // Remove out-of-bound indexes
+    ].filter(i => 0 <= i <= tiles.length) // Remove out-of-bound indexes
 
     // Toggle each selected tile's status
     targets.forEach(t => (tiles[t] = tiles[t] ? 0 : 1))
@@ -81,7 +81,11 @@ class Grid extends React.Component {
     )
 
     let copyStateToClipboardButton = (
-      <button onClick={() => navigator.clipboard.writeText(this.state.tiles)}>
+      <button
+        onClick={() =>
+          navigator.clipboard.writeText(this.state.tiles.slice(0,24))
+        }
+      >
         Copy Grid
       </button>
     )


### PR DESCRIPTION
- Ensures copied arrays are at most 24 elements long
- Unsure why grid array is becoming longer than 24 elements, but this fix will work as a temporary solution